### PR TITLE
fix(github): use /{repo}/releases/latest for producing latest release

### DIFF
--- a/api/repo/[owner]/[name]/releases/latest.rs
+++ b/api/repo/[owner]/[name]/releases/latest.rs
@@ -22,7 +22,7 @@ fn handler(request: Request) -> Result<impl IntoResponse, VercelError> {
     let repo = (&query_params).into();
     let manager = GitHubManager::new(GitHubClient::new(api_key));
 
-    match manager.get_latest_release(&repo, query_params.has_flag("include_prerelease")) {
+    match manager.get_latest_release(&repo) {
         Ok(latest_release) => mason_registry_api::ok_json(latest_release),
         Err(err) => mason_registry_api::err_json(err),
     }

--- a/api/src/github/client/mod.rs
+++ b/api/src/github/client/mod.rs
@@ -32,6 +32,7 @@ enum GitHubApiEndpoint<'a> {
     Link(Link),
     Releases(&'a GitHubRepo),
     ReleaseTag(&'a GitHubRepo, &'a GitHubTag),
+    LatestRelease(&'a GitHubRepo),
     GitRef(&'a GitHubRepo, &'a dyn GitHubRefId),
 }
 
@@ -52,6 +53,9 @@ impl<'a> Display for GitHubApiEndpoint<'a> {
             GitHubApiEndpoint::Releases(repo) => {
                 f.write_fmt(format_args!("repos/{}/releases", repo))
             }
+            GitHubApiEndpoint::LatestRelease(repo) => {
+                f.write_fmt(format_args!("repos/{}/releases/latest", repo))
+            },
             GitHubApiEndpoint::ReleaseTag(repo, release_tag) => f.write_fmt(format_args!(
                 "repos/{}/releases/tags/{}",
                 repo, release_tag
@@ -191,6 +195,10 @@ impl GitHubClient {
         self.client
             .get(GitHubApiEndpoint::ReleaseTag(&repo, &release))?
             .try_into()
+    }
+
+    pub fn fetch_latest_release(&self, repo: &GitHubRepo) -> Result<GitHubResponse<GitHubReleaseDto>, reqwest::Error> {
+        self.client.get(GitHubApiEndpoint::LatestRelease(&repo))?.try_into()
     }
 
     fn graphql<Variables: Serialize>(

--- a/api/src/github/manager.rs
+++ b/api/src/github/manager.rs
@@ -93,37 +93,9 @@ impl GitHubManager {
 
     pub fn get_latest_release(
         &self,
-        repo: &GitHubRepo,
-        include_prerelease: bool,
+        repo: &GitHubRepo
     ) -> Result<GitHubReleaseDto, GitHubError> {
-        let is_latest_release = |release: &GitHubReleaseDto| {
-            if include_prerelease {
-                !release.draft
-            } else {
-                !release.draft && !release.prerelease
-            }
-        };
-        let releases = self.client.paginate(
-            || {
-                self.client.fetch_releases(
-                    &repo,
-                    Some(GitHubPagination {
-                        page: 1,
-                        per_page: GitHubPagination::MAX_PAGE_LIMIT,
-                    }),
-                )
-            },
-            |response| {
-                (&response.data)
-                    .into_iter()
-                    .find(|r| is_latest_release(*r))
-                    .is_none()
-            },
-        )?;
-        releases
-            .into_iter()
-            .find(is_latest_release)
-            .ok_or_else(|| GitHubError::ResourceNotFound { source: None })
+        Ok(self.client.fetch_latest_release(&repo)?.data)
     }
 
     pub fn get_release_by_tag(


### PR DESCRIPTION
This has the drawback of not being able to ask for pre-releases, but
that was never a feature used in Mason anyways.
