### PR TITLE
fix(rubygems): remove description field

### DIFF
--- a/src/rubygems/client/spec.rs
+++ b/src/rubygems/client/spec.rs
@@ -10,7 +10,6 @@ pub struct RubyGemDto {
 
 #[derive(Deserialize, Serialize)]
 pub struct RubyGemVersionDto {
-    pub description: String,
     #[serde(rename(deserialize = "number"))]
     pub version: String,
     pub licenses: Option<Vec<String>>,


### PR DESCRIPTION
This is unused (and if it were to be kept it needs to be an Option).
